### PR TITLE
Fix use of array/string offset with curly braces

### DIFF
--- a/Helper/Systemcheck.php
+++ b/Helper/Systemcheck.php
@@ -153,7 +153,7 @@ class Systemcheck extends \Magento\Framework\App\Helper\AbstractHelper
     {
         $val = trim($val);
         $valInt = (int)$val;
-        $last = strtolower($val{strlen($val)-1});
+        $last = strtolower($val[strlen($val)-1]);
         switch($last) {
             case 'g':
                 $valInt *= 1024;


### PR DESCRIPTION
When using PHP 7.4 there is an error during `setup:di:compile` in the cobby module.

**Deprecated: Array and string offset access syntax with curly braces is deprecated in /var/www/html/vendor/mash2/cobby-magento2/Helper/Systemcheck.php on line 156**

This PR fixes the issue and uses a compatible syntax.